### PR TITLE
Subscription support in acl_app

### DIFF
--- a/translib/acl_app.go
+++ b/translib/acl_app.go
@@ -29,6 +29,7 @@ import (
 
 	"github.com/Azure/sonic-mgmt-common/translib/db"
 	"github.com/Azure/sonic-mgmt-common/translib/ocbinds"
+	"github.com/Azure/sonic-mgmt-common/translib/path"
 	"github.com/Azure/sonic-mgmt-common/translib/tlerr"
 
 	log "github.com/golang/glog"
@@ -171,14 +172,6 @@ func (app *AclApp) translateGet(dbs [db.MaxDB]*db.DB) error {
 func (app *AclApp) translateAction(dbs [db.MaxDB]*db.DB) error {
 	err := errors.New("Not supported")
 	return err
-}
-
-func (app *AclApp) translateSubscribe(req *translateSubRequest) (*translateSubResponse, error) {
-	return defaultSubscribeResponse(req.path)
-}
-
-func (app *AclApp) processSubscribe(req *processSubRequest) (processSubResponse, error) {
-	return processSubResponse{}, errors.New("Not supported")
 }
 
 func (app *AclApp) processCreate(d *db.DB) (SetResponse, error) {
@@ -1661,6 +1654,19 @@ func getAclTypeOCEnumFromName(val string) (ocbinds.E_OpenconfigAcl_ACL_TYPE, err
 	}
 }
 
+func convertSonicAclTypeToOC(aclType string) (ocbinds.E_OpenconfigAcl_ACL_TYPE, string) {
+	switch aclType {
+	case SONIC_ACL_TYPE_IPV4:
+		return ocbinds.OpenconfigAcl_ACL_TYPE_ACL_IPV4, "ACL_IPV4"
+	case SONIC_ACL_TYPE_IPV6:
+		return ocbinds.OpenconfigAcl_ACL_TYPE_ACL_IPV6, "ACL_IPV6"
+	case SONIC_ACL_TYPE_L2:
+		return ocbinds.OpenconfigAcl_ACL_TYPE_ACL_L2, "ACL_L2"
+	default:
+		return ocbinds.OpenconfigAcl_ACL_TYPE_UNSET, ""
+	}
+}
+
 func getAclKeyStrFromOCKey(aclname string, acltype ocbinds.E_OpenconfigAcl_ACL_TYPE) string {
 	aclN := strings.Replace(strings.Replace(aclname, " ", "_", -1), "-", "_", -1)
 	aclT := acltype.ΛMap()["E_OpenconfigAcl_ACL_TYPE"][int64(acltype)].Name
@@ -1675,4 +1681,132 @@ to visited to fill the data or not.
 */
 func isSubtreeRequest(targetUriPath string, nodePath string) bool {
 	return strings.HasPrefix(targetUriPath, nodePath)
+}
+
+func (app *AclApp) translateSubscribe(req *translateSubRequest) (*translateSubResponse, error) {
+	ymap := yangMapTree{
+		subtree: map[string]*yangMapTree{
+			"acl-sets/acl-set": {
+				mapFunc: app.translateSubscribeAclSet,
+				subtree: map[string]*yangMapTree{
+					"acl-entries/acl-entry": {
+						mapFunc: app.translateSubscribeAclEntry,
+					},
+				},
+			},
+		}}
+
+	nb := notificationInfoBuilder{
+		pathInfo: NewPathInfo(req.path),
+		yangMap:  ymap,
+	}
+	return nb.Build()
+}
+
+func (app *AclApp) translateSubscribeAclSet(nb *notificationInfoBuilder) error {
+	aclName := nb.pathInfo.StringVar("name", "*")
+	aclType := nb.pathInfo.StringVar("type", "*")
+
+	nb.New().PathKey("name", aclName).PathKey("type", aclType)
+	nb.Table(db.ConfigDB, ACL_TABLE).Key(aclName + "_" + aclType)
+	if nb.SetFieldPrefix("config") {
+		nb.Field("description", ACL_DESCRIPTION)
+	}
+	if nb.SetFieldPrefix("state") {
+		nb.Field("description", ACL_DESCRIPTION)
+	}
+
+	return nil
+}
+
+func (app *AclApp) translateSubscribeAclEntry(nb *notificationInfoBuilder) error {
+	aclName := nb.pathInfo.StringVar("name", "*")
+	aclType := nb.pathInfo.StringVar("type", "*")
+	ruleSeq := nb.pathInfo.StringVar("sequence-id", "*")
+
+	nb.New().PathKey("sequence-id", ruleSeq)
+	nb.Table(db.ConfigDB, RULE_TABLE).Key(aclName+"_"+aclType, "RULE_"+ruleSeq)
+
+	ipAclFieldSetter := func(prefix string) {
+		if nb.SetFieldPrefix(prefix) {
+			nb.Field("source-address", "SRC_IP")
+			nb.Field("destination-address", "DST_IP")
+			nb.Field("dscp", "DSCP")
+			nb.Field("protocol", "IP_PROTOCOL")
+		}
+	}
+	ipv6AclFieldSetter := func(prefix string) {
+		if nb.SetFieldPrefix(prefix) {
+			nb.Field("source-address", "SRC_IPV6")
+			nb.Field("destination-address", "DST_IPV6")
+			nb.Field("dscp", "DSCP")
+			nb.Field("protocol", "IP_PROTOCOL")
+		}
+	}
+	ipTransportFieldSetter := func(prefix string) {
+		if nb.SetFieldPrefix(prefix) {
+			nb.Field("source-port", "L4_SRC_PORT")
+			nb.Field("source-port", "L4_SRC_PORT_RANGE")
+			nb.Field("destination-port", "L4_DST_PORT")
+			nb.Field("destination-port", "L4_DST_PORT_RANGE")
+			nb.Field("tcp-flags", "TCP_FLAGS")
+		}
+	}
+	if wildcardMatch(aclType, "ACL_IPV4") {
+		ipAclFieldSetter("ipv4/config")
+		ipAclFieldSetter("ipv4/state")
+		ipTransportFieldSetter("transport/config")
+		ipTransportFieldSetter("transport/state")
+	}
+	if wildcardMatch(aclType, "ACL_IPV6") {
+		ipv6AclFieldSetter("ipv6/config")
+		ipv6AclFieldSetter("ipv6/state")
+		ipTransportFieldSetter("transport/config")
+		ipTransportFieldSetter("transport/state")
+	}
+	if nb.SetFieldPrefix("actions/config") {
+		nb.Field("forwarding-action", "PACKET_ACTION")
+	}
+	if nb.SetFieldPrefix("actions/state") {
+		nb.Field("forwarding-action", "PACKET_ACTION")
+	}
+
+	return nil
+}
+
+func (app *AclApp) processSubscribe(req *processSubRequest) (processSubResponse, error) {
+	resp := processSubResponse{
+		path: req.path,
+	}
+
+	switch req.table.Name {
+	case ACL_TABLE:
+		if path.GetElemAt(resp.path, 2) != "acl-set" {
+			return resp, tlerr.New("Unknown path template: %v", path.String(req.path))
+		}
+
+		_, aclTypeStr := convertSonicAclTypeToOC(req.entry.Get(ACL_TYPE))
+		aclName := strings.TrimSuffix(req.key.Get(0), "_"+aclTypeStr)
+		path.SetKeyAt(resp.path, 2, "name", aclName)
+		path.SetKeyAt(resp.path, 2, "type", aclTypeStr)
+
+	case RULE_TABLE:
+		aclName, aclTypeStr := req.key.Get(0), ""
+		aclEntry, err := req.dbs[db.ConfigDB].GetEntry(&db.TableSpec{Name: ACL_TABLE}, asKey(aclName))
+		if err != nil {
+			return resp, err
+		} else {
+			_, aclTypeStr = convertSonicAclTypeToOC(aclEntry.Get(ACL_TYPE))
+			aclName = strings.TrimSuffix(aclName, "_"+aclTypeStr)
+		}
+
+		path.SetKeyAt(resp.path, 2, "name", aclName)
+		path.SetKeyAt(resp.path, 2, "type", aclTypeStr)
+		path.SetKeyAt(resp.path, 4, "sequence-id", strings.TrimPrefix(req.key.Get(1), "RULE_"))
+
+	default:
+		return resp, tlerr.New("Unknown table: %s", req.table.Name)
+	}
+
+	return resp, nil
 }

--- a/translib/app_utils.go
+++ b/translib/app_utils.go
@@ -25,7 +25,6 @@ import (
 
 	"github.com/Azure/sonic-mgmt-common/translib/db"
 	"github.com/Azure/sonic-mgmt-common/translib/ocbinds"
-	"github.com/Azure/sonic-mgmt-common/translib/path"
 	"github.com/Azure/sonic-mgmt-common/translib/tlerr"
 
 	log "github.com/golang/glog"
@@ -229,18 +228,4 @@ func asKey(parts ...string) db.Key {
 
 func createEmptyDbValue(fieldName string) db.Value {
 	return db.Value{Field: map[string]string{fieldName: ""}}
-}
-
-func defaultSubscribeResponse(reqPath string) (*translateSubResponse, error) {
-	p, err := path.New(reqPath)
-	if err != nil {
-		return nil, err
-	}
-	resp := new(translateSubResponse)
-	resp.ntfAppInfoTrgt = append(resp.ntfAppInfoTrgt, &notificationAppInfo{
-		path:                p,
-		dbno:                db.MaxDB, // non-DB
-		isOnChangeSupported: false,
-	})
-	return resp, nil
 }

--- a/translib/path_utils.go
+++ b/translib/path_utils.go
@@ -54,6 +54,16 @@ func (p *PathInfo) Var(name string) string {
 	return p.Vars[name]
 }
 
+// StringVar returns the string value for a path variable if
+// it exists; otherwise returns the specified default value.
+func (p *PathInfo) StringVar(name, defalt string) string {
+	if v, ok := p.Vars[name]; ok {
+		return v
+	} else {
+		return defalt
+	}
+}
+
 // IntVar returns the value for a path variable as an int.
 // Returns 0 if no such variable exists. Returns an error
 // if the value is not an integer.

--- a/translib/subscribe_app_utils.go
+++ b/translib/subscribe_app_utils.go
@@ -1,0 +1,331 @@
+////////////////////////////////////////////////////////////////////////////////
+//                                                                            //
+//  Copyright 2023 Broadcom. The term Broadcom refers to Broadcom Inc. and/or //
+//  its subsidiaries.                                                         //
+//                                                                            //
+//  Licensed under the Apache License, Version 2.0 (the "License");           //
+//  you may not use this file except in compliance with the License.          //
+//  You may obtain a copy of the License at                                   //
+//                                                                            //
+//     http://www.apache.org/licenses/LICENSE-2.0                             //
+//                                                                            //
+//  Unless required by applicable law or agreed to in writing, software       //
+//  distributed under the License is distributed on an "AS IS" BASIS,         //
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  //
+//  See the License for the specific language governing permissions and       //
+//  limitations under the License.                                            //
+//                                                                            //
+////////////////////////////////////////////////////////////////////////////////
+
+package translib
+
+import (
+	"strings"
+
+	"github.com/Azure/sonic-mgmt-common/translib/db"
+	"github.com/Azure/sonic-mgmt-common/translib/internal/apis"
+	"github.com/Azure/sonic-mgmt-common/translib/path"
+	"github.com/Azure/sonic-mgmt-common/translib/tlerr"
+	log "github.com/golang/glog"
+	"github.com/openconfig/gnmi/proto/gnmi"
+	"github.com/openconfig/ygot/ygot"
+)
+
+// notificationInfoBuilder provides utility APIs to build notificationAppInfo
+// data.
+type notificationInfoBuilder struct {
+	pathInfo *PathInfo
+	yangMap  yangMapTree
+
+	primaryInfos []*notificationAppInfo
+	subtreeInfos []*notificationAppInfo
+
+	requestPath *gnmi.Path
+	currentPath *gnmi.Path // Path cone to be used in notificationAppInfo
+	currentIndx int        // Current yangMap node's element in currentPath
+	fieldPrefix string     // Yang prefix to be used in Field()
+	fieldFilter string     // Field name filter
+	treeDepth   int        // depth of current call tree wrt requestPath
+	currentInfo *notificationAppInfo
+	subtreePath []string // subpath to current node relative to currentInfo.path
+}
+
+type yangMapFunc func(nb *notificationInfoBuilder) error
+
+type yangMapTree struct {
+	mapFunc yangMapFunc
+	subtree map[string]*yangMapTree
+}
+
+func (nb *notificationInfoBuilder) Build() (*translateSubResponse, error) {
+	log.Infof("translateSubscribe( %s )", nb.pathInfo.Path)
+
+	var err error
+	nb.requestPath, err = ygot.StringToStructuredPath(nb.pathInfo.Path)
+	if err != nil {
+		log.Warningf("Invalid subscribe path: \"%s\"; err=%v", nb.pathInfo.Path, err)
+		return nil, tlerr.InvalidArgs("Invalid subscribe path")
+	}
+
+	// Find matching yangMapTree node
+	index, ymap, recurse := nb.yangMap.match(nb.requestPath, 1)
+
+	log.Infof("Path match index %d", index)
+	if index < 0 {
+		return nil, tlerr.InvalidArgsError{Path: nb.pathInfo.Path, Format: "Invalid path"}
+	}
+
+	nb.currentIndx = index
+	nb.currentPath = nb.requestPath
+	if err := ymap.collect(nb, recurse); err != nil {
+		log.Warningf("translateSubscribe failed for path: \"%s\"; err=%s", nb.pathInfo.Path, err)
+		return nil, tlerr.New("Internal error")
+	}
+
+	log.Infof("Found %d primary and %d subtree notificationAppInfo",
+		len(nb.primaryInfos), len(nb.subtreeInfos))
+
+	return &translateSubResponse{
+		ntfAppInfoTrgt:      nb.primaryInfos,
+		ntfAppInfoTrgtChlds: nb.subtreeInfos,
+	}, nil
+}
+
+func (nb *notificationInfoBuilder) New() *notificationInfoBuilder {
+	nb.currentInfo = &notificationAppInfo{
+		path:                nb.currentPath,
+		dbno:                db.MaxDB,
+		isOnChangeSupported: true,
+		pType:               OnChange,
+	}
+	nb.subtreePath = nil // nb.currentPath already has the subpath
+	if nb.treeDepth == 0 {
+		nb.primaryInfos = append(nb.primaryInfos, nb.currentInfo)
+	} else {
+		nb.subtreeInfos = append(nb.subtreeInfos, nb.currentInfo)
+	}
+	return nb
+}
+
+func (nb *notificationInfoBuilder) PathKey(name, value string) *notificationInfoBuilder {
+	path.SetKeyAt(nb.currentPath, nb.currentIndx, name, value)
+	return nb
+}
+
+func (nb *notificationInfoBuilder) Table(dbno db.DBNum, tableName string) *notificationInfoBuilder {
+	nb.currentInfo.dbno = dbno
+	nb.currentInfo.table = &db.TableSpec{Name: tableName}
+	if dbno == db.CountersDB {
+		nb.OnChange(false)
+	}
+	return nb
+}
+
+func (nb *notificationInfoBuilder) Key(keyComp ...string) *notificationInfoBuilder {
+	nb.currentInfo.key = &db.Key{Comp: keyComp}
+	return nb
+}
+
+func (nb *notificationInfoBuilder) Field(yangAttr, dbField string) *notificationInfoBuilder {
+	// Ignore unwanted fields
+	if len(nb.fieldFilter) != 0 {
+		if yangAttr != nb.fieldFilter {
+			return nb
+		}
+
+		// When request path points to a leaf, we do not want the
+		// yang leaf name in the fields map!!
+		yangAttr = ""
+	}
+
+	isAdded := false
+	for _, dbFldYgPath := range nb.currentInfo.dbFldYgPathInfoList {
+		if dbFldYgPath.rltvPath == nb.fieldPrefix {
+			if v, exists := dbFldYgPath.dbFldYgPathMap[dbField]; exists {
+				dbFldYgPath.dbFldYgPathMap[dbField] = v + "," + yangAttr
+			} else {
+				dbFldYgPath.dbFldYgPathMap[dbField] = yangAttr
+			}
+			isAdded = true
+			break
+		}
+	}
+
+	if !isAdded {
+		dbFldInfo := dbFldYgPathInfo{nb.fieldPrefix, make(map[string]string)}
+		dbFldInfo.dbFldYgPathMap[dbField] = yangAttr
+		nb.currentInfo.dbFldYgPathInfoList = append(nb.currentInfo.dbFldYgPathInfoList, &dbFldInfo)
+	}
+
+	return nb
+}
+
+func (nb *notificationInfoBuilder) SetFieldPrefix(prefix string) bool {
+	i := nb.currentIndx + 1
+	n := path.Len(nb.currentPath)
+
+	if len(nb.subtreePath) > 0 {
+		prefix = strings.Join(nb.subtreePath, "/") + "/" + prefix
+		log.Infof("Prefix updated to %v", prefix)
+	}
+	if i >= n {
+		// Request does not contain any additional elements beyond
+		// current path. Accept all sub containers & fields
+		nb.fieldPrefix = prefix
+		nb.fieldFilter = ""
+		return true
+	}
+
+	pparts := strings.Split(prefix, "/")
+	for j, p := range pparts {
+		if p != nb.currentPath.Elem[i].Name {
+			return false
+		}
+
+		i++
+		if i >= n {
+			if j == len(pparts) { // exact match
+				nb.fieldPrefix = ""
+			} else { // partial match
+				nb.fieldPrefix = strings.Join(pparts[j+1:], "/")
+			}
+			nb.fieldFilter = ""
+			return true
+		}
+	}
+
+	// Current path is still longer than given prefix. Must be
+	// field name filter
+	nb.fieldPrefix = ""
+	nb.fieldFilter = nb.currentPath.Elem[i].Name
+	return true
+}
+
+func (nb *notificationInfoBuilder) OnChange(flag bool) *notificationInfoBuilder {
+	nb.currentInfo.isOnChangeSupported = flag
+	return nb
+}
+
+func (nb *notificationInfoBuilder) Interval(secs int) *notificationInfoBuilder {
+	nb.currentInfo.mInterval = secs
+	return nb
+}
+
+func (nb *notificationInfoBuilder) Preferred(mode NotificationType) *notificationInfoBuilder {
+	nb.currentInfo.pType = mode
+	return nb
+}
+
+func (nb *notificationInfoBuilder) HandlerFunc(f apis.ProcessOnChange) *notificationInfoBuilder {
+	nb.currentInfo.handlerFunc = f
+	return nb
+}
+
+func (nb *notificationInfoBuilder) Opaque(o interface{}) *notificationInfoBuilder {
+	nb.currentInfo.opaque = o
+	return nb
+}
+
+func (y *yangMapTree) match(reqPath *gnmi.Path, index int) (int, *yangMapTree, bool) {
+	size := path.Len(reqPath)
+	if len(y.subtree) == 0 || index >= size {
+		return index - 1, y, true
+	}
+
+	next := reqPath.Elem[index].Name
+
+	for segment, submap := range y.subtree {
+		parts := strings.Split(segment, "/")
+		if parts[0] != next {
+			continue
+		}
+
+		// Reuse current handler func if subtree map is nil.
+		if submap == nil {
+			temp := yangMapTree{mapFunc: y.mapFunc}
+			return temp.match(reqPath, index)
+		}
+
+		nparts := len(parts)
+		if path.MergeElemsAt(reqPath, index, parts...) == nparts {
+			return submap.match(reqPath, index+nparts)
+		}
+		break // no match
+	}
+
+	// There are no subtree mappings matching the request path.
+	// Use the current node's func, but do not recurse into subtree.
+	if y.mapFunc != nil {
+		return index - 1, y, false
+	}
+
+	return -1, nil, false
+}
+
+func (y *yangMapTree) collect(nb *notificationInfoBuilder, recurse bool) error {
+	// Reset previous states
+	nb.fieldPrefix = ""
+	nb.fieldFilter = ""
+	bakupIndx := nb.currentIndx
+	bakupPath := nb.currentPath
+	bakupDepth := nb.treeDepth
+
+	// Invoke yangMapFunc to collect notificationAppInfo
+	if y.mapFunc != nil {
+		if err := y.mapFunc(nb); err != nil {
+			return err
+		}
+
+		nb.treeDepth++
+	}
+	if !recurse {
+		return nil
+	}
+
+	baseNInfo := nb.currentInfo
+
+	// Recursively collect from subtree
+	for subpath, subnode := range y.subtree {
+		if subnode == nil {
+			continue
+		}
+
+		parts := strings.Split(subpath, "/")
+		nb.currentIndx = bakupIndx + len(parts)
+		nb.currentPath = path.SubPath(bakupPath, 0, bakupIndx+1)
+		path.AppendElems(nb.currentPath, parts...)
+
+		if nb.currentInfo == baseNInfo {
+			nb.subtreePath = append(nb.subtreePath, subpath)
+		}
+
+		if err := subnode.collect(nb, true); err != nil {
+			return err
+		}
+
+		if len(nb.subtreePath) != 0 {
+			nb.subtreePath = nb.subtreePath[:len(nb.subtreePath)-1]
+		}
+	}
+
+	nb.treeDepth = bakupDepth
+	return nil
+}
+
+func wildcardMatch(v1, v2 string) bool {
+	return v1 == v2 || v1 == "*"
+}
+
+func defaultSubscribeResponse(reqPath string) (*translateSubResponse, error) {
+	p, err := path.New(reqPath)
+	if err != nil {
+		return nil, err
+	}
+	resp := new(translateSubResponse)
+	resp.ntfAppInfoTrgt = append(resp.ntfAppInfoTrgt, &notificationAppInfo{
+		path:                p,
+		dbno:                db.MaxDB, // non-DB
+		isOnChangeSupported: false,
+	})
+	return resp, nil
+}


### PR DESCRIPTION
* Implement translateSubscribe() and processSubscribe() in acl_app. Covers /openconfig-acl:acl/acl-sets and its child paths. Acl binding paths are not covered
* notificationInfoBuilder utility to assist generation of db mappings